### PR TITLE
Add linearization to SweetFX effects.

### DIFF
--- a/Shaders/ASCII.fx
+++ b/Shaders/ASCII.fx
@@ -147,12 +147,7 @@ uniform bool Ascii_dithering_debug_gradient <
 | :: Sampler and timers :: |
 '-------------------------*/
 
-//#define asciiSampler ReShade::BackBuffer
-sampler2D asciiSampler
-{
-	Texture = ReShade::BackBufferTex;
-	SRGBTexture = true;
-};
+#define asciiSampler ReShade::BackBuffer
 
 uniform float timer < source = "timer"; >;
 uniform float framecount < source = "framecount"; >;
@@ -447,7 +442,6 @@ technique ASCII
 	{
 		VertexShader=PostProcessVS;
 		PixelShader=PS_Ascii;
-		SRGBWriteEnable=true;
 	}
 }
 

--- a/Shaders/ASCII.fx
+++ b/Shaders/ASCII.fx
@@ -147,7 +147,12 @@ uniform bool Ascii_dithering_debug_gradient <
 | :: Sampler and timers :: |
 '-------------------------*/
 
-#define asciiSampler ReShade::BackBuffer
+//#define asciiSampler ReShade::BackBuffer
+sampler2D asciiSampler
+{
+	Texture = ReShade::BackBufferTex;
+	SRGBTexture = true;
+};
 
 uniform float timer < source = "timer"; >;
 uniform float framecount < source = "framecount"; >;
@@ -442,6 +447,7 @@ technique ASCII
 	{
 		VertexShader=PostProcessVS;
 		PixelShader=PS_Ascii;
+		SRGBWriteEnable=true;
 	}
 }
 

--- a/Shaders/Cartoon.fx
+++ b/Shaders/Cartoon.fx
@@ -24,7 +24,7 @@ uniform float EdgeSlope < __UNIFORM_SLIDER_FLOAT1
 sampler2D BackBuffer
 {
 	Texture = ReShade::BackBufferTex;
-	SRGBTexture = SWEETFX_CARTOON_SRGB;
+	SRGBTexture = SWEETFX_CARTOON_SRGB && (BUFFER_COLOR_SPACE==1);
 };
 
 float3 CartoonPass(float4 position : SV_Position, float2 texcoord : TEXCOORD) : SV_Target
@@ -48,6 +48,6 @@ technique Cartoon
 	{
 		VertexShader = PostProcessVS;
 		PixelShader = CartoonPass;
-		SRGBWriteEnable = SWEETFX_CARTOON_SRGB;
+		SRGBWriteEnable = SWEETFX_CARTOON_SRGB && (BUFFER_COLOR_SPACE==1);
 	}
 }

--- a/Shaders/Cartoon.fx
+++ b/Shaders/Cartoon.fx
@@ -17,15 +17,21 @@ uniform float EdgeSlope < __UNIFORM_SLIDER_FLOAT1
 
 #include "ReShade.fxh"
 
+sampler2D BackBuffer
+{
+	Texture = ReShade::BackBufferTex;
+	SRGBTexture = true;
+};
+
 float3 CartoonPass(float4 position : SV_Position, float2 texcoord : TEXCOORD) : SV_Target
 {
-	float3 color = tex2D(ReShade::BackBuffer, texcoord).rgb;
+	float3 color = tex2D(BackBuffer, texcoord).rgb;
 	const float3 coefLuma = float3(0.2126, 0.7152, 0.0722);
 
-	float diff1 = dot(coefLuma, tex2D(ReShade::BackBuffer, texcoord + BUFFER_PIXEL_SIZE).rgb);
-	diff1 = dot(float4(coefLuma, -1.0), float4(tex2D(ReShade::BackBuffer, texcoord - BUFFER_PIXEL_SIZE).rgb , diff1));
-	float diff2 = dot(coefLuma, tex2D(ReShade::BackBuffer, texcoord + BUFFER_PIXEL_SIZE * float2(1, -1)).rgb);
-	diff2 = dot(float4(coefLuma, -1.0), float4(tex2D(ReShade::BackBuffer, texcoord + BUFFER_PIXEL_SIZE * float2(-1, 1)).rgb , diff2));
+	float diff1 = dot(coefLuma, tex2D(BackBuffer, texcoord + BUFFER_PIXEL_SIZE).rgb);
+	diff1 = dot(float4(coefLuma, -1.0), float4(tex2D(BackBuffer, texcoord - BUFFER_PIXEL_SIZE).rgb , diff1));
+	float diff2 = dot(coefLuma, tex2D(BackBuffer, texcoord + BUFFER_PIXEL_SIZE * float2(1, -1)).rgb);
+	diff2 = dot(float4(coefLuma, -1.0), float4(tex2D(BackBuffer, texcoord + BUFFER_PIXEL_SIZE * float2(-1, 1)).rgb , diff2));
 
 	float edge = dot(float2(diff1, diff2), float2(diff1, diff2));
 
@@ -38,5 +44,6 @@ technique Cartoon
 	{
 		VertexShader = PostProcessVS;
 		PixelShader = CartoonPass;
+		SRGBWriteEnable = true;
 	}
 }

--- a/Shaders/Cartoon.fx
+++ b/Shaders/Cartoon.fx
@@ -17,10 +17,14 @@ uniform float EdgeSlope < __UNIFORM_SLIDER_FLOAT1
 
 #include "ReShade.fxh"
 
+#ifndef SWEETFX_CARTOON_SRGB
+#define SWEETFX_CARTOON_SRGB 1
+#endif
+
 sampler2D BackBuffer
 {
 	Texture = ReShade::BackBufferTex;
-	SRGBTexture = true;
+	SRGBTexture = SWEETFX_CARTOON_SRGB;
 };
 
 float3 CartoonPass(float4 position : SV_Position, float2 texcoord : TEXCOORD) : SV_Target
@@ -44,6 +48,6 @@ technique Cartoon
 	{
 		VertexShader = PostProcessVS;
 		PixelShader = CartoonPass;
-		SRGBWriteEnable = true;
+		SRGBWriteEnable = SWEETFX_CARTOON_SRGB;
 	}
 }

--- a/Shaders/ChromaticAberration.fx
+++ b/Shaders/ChromaticAberration.fx
@@ -17,13 +17,19 @@ uniform float Strength < __UNIFORM_SLIDER_FLOAT1
 
 #include "ReShade.fxh"
 
+sampler2D BackBuffer
+{
+	Texture = ReShade::BackBufferTex;
+	SRGBTexture = true;
+};
+
 float3 ChromaticAberrationPass(float4 vpos : SV_Position, float2 texcoord : TexCoord) : SV_Target
 {
-	float3 color, colorInput = tex2D(ReShade::BackBuffer, texcoord).rgb;
+	float3 color, colorInput = tex2D(BackBuffer, texcoord).rgb;
 	// Sample the color components
-	color.r = tex2D(ReShade::BackBuffer, texcoord + (BUFFER_PIXEL_SIZE * Shift)).r;
+	color.r = tex2D(BackBuffer, texcoord + (BUFFER_PIXEL_SIZE * Shift)).r;
 	color.g = colorInput.g;
-	color.b = tex2D(ReShade::BackBuffer, texcoord - (BUFFER_PIXEL_SIZE * Shift)).b;
+	color.b = tex2D(BackBuffer, texcoord - (BUFFER_PIXEL_SIZE * Shift)).b;
 
 	// Adjust the strength of the effect
 	return lerp(colorInput, color, Strength);
@@ -35,5 +41,6 @@ technique CA
 	{
 		VertexShader = PostProcessVS;
 		PixelShader = ChromaticAberrationPass;
+		SRGBWriteEnable = true;
 	}
 }

--- a/Shaders/ChromaticAberration.fx
+++ b/Shaders/ChromaticAberration.fx
@@ -17,10 +17,14 @@ uniform float Strength < __UNIFORM_SLIDER_FLOAT1
 
 #include "ReShade.fxh"
 
+#ifndef SWEETFX_CA_SRGB
+#define SWEETFX_CA_SRGB 1
+#endif
+
 sampler2D BackBuffer
 {
 	Texture = ReShade::BackBufferTex;
-	SRGBTexture = true;
+	SRGBTexture = SWEETFX_CA_SRGB;
 };
 
 float3 ChromaticAberrationPass(float4 vpos : SV_Position, float2 texcoord : TexCoord) : SV_Target
@@ -41,6 +45,6 @@ technique CA
 	{
 		VertexShader = PostProcessVS;
 		PixelShader = ChromaticAberrationPass;
-		SRGBWriteEnable = true;
+		SRGBWriteEnable = SWEETFX_CA_SRGB;
 	}
 }

--- a/Shaders/ChromaticAberration.fx
+++ b/Shaders/ChromaticAberration.fx
@@ -24,7 +24,7 @@ uniform float Strength < __UNIFORM_SLIDER_FLOAT1
 sampler2D BackBuffer
 {
 	Texture = ReShade::BackBufferTex;
-	SRGBTexture = SWEETFX_CA_SRGB;
+	SRGBTexture = SWEETFX_CA_SRGB && (BUFFER_COLOR_SPACE==1);
 };
 
 float3 ChromaticAberrationPass(float4 vpos : SV_Position, float2 texcoord : TexCoord) : SV_Target
@@ -45,6 +45,6 @@ technique CA
 	{
 		VertexShader = PostProcessVS;
 		PixelShader = ChromaticAberrationPass;
-		SRGBWriteEnable = SWEETFX_CA_SRGB;
+		SRGBWriteEnable = SWEETFX_CA_SRGB && (BUFFER_COLOR_SPACE==1);
 	}
 }

--- a/Shaders/ColorMatrix.fx
+++ b/Shaders/ColorMatrix.fx
@@ -30,9 +30,19 @@ uniform float Strength < __UNIFORM_SLIDER_FLOAT1
 
 #include "ReShade.fxh"
 
+#ifndef SWEETFX_MATRIX_SRGB
+#define SWEETFX_MATRIX_SRGB 1
+#endif
+
+sampler2D BackBuffer
+{
+	Texture = ReShade::BackBufferTex;
+	SRGBTexture = SWEETFX_MATRIX_SRGB && (BUFFER_COLOR_SPACE==1);
+};
+
 float3 ColorMatrixPass(float4 position : SV_Position, float2 texcoord : TexCoord) : SV_Target
 {
-	float3 color = tex2D(ReShade::BackBuffer, texcoord).rgb;
+	float3 color = tex2D(BackBuffer, texcoord).rgb;
 
 	const float3x3 ColorMatrix = float3x3(ColorMatrix_Red, ColorMatrix_Green, ColorMatrix_Blue);
 	color = lerp(color, mul(ColorMatrix, color), Strength);
@@ -46,5 +56,6 @@ technique ColorMatrix
 	{
 		VertexShader = PostProcessVS;
 		PixelShader = ColorMatrixPass;
+		SRGBWriteEnable = SWEETFX_MATRIX_SRGB && (BUFFER_COLOR_SPACE==1);
 	}
 }

--- a/Shaders/Curves.fx
+++ b/Shaders/Curves.fx
@@ -25,9 +25,19 @@ uniform float Contrast < __UNIFORM_SLIDER_FLOAT1
 
 #include "ReShade.fxh"
 
+#ifndef SWEETFX_CURVES_SRGB
+#define SWEETFX_CURVES_SRGB 1
+#endif
+
+sampler2D BackBuffer
+{
+	Texture = ReShade::BackBufferTex;
+	SRGBTexture = SWEETFX_CURVES_SRGB && (BUFFER_COLOR_SPACE==1);
+};
+
 float4 CurvesPass(float4 vpos : SV_Position, float2 texcoord : TexCoord) : SV_Target
 {
-	float4 colorInput = tex2D(ReShade::BackBuffer, texcoord);
+	float4 colorInput = tex2D(BackBuffer, texcoord);
 	float3 lumCoeff = float3(0.2126, 0.7152, 0.0722);  //Values to calculate luma with
 	float Contrast_blend = Contrast; 
 	const float PI = 3.1415927;
@@ -195,5 +205,6 @@ technique Curves
 	{
 		VertexShader = PostProcessVS;
 		PixelShader = CurvesPass;
+		SRGBWriteEnable = SWEETFX_CURVES_SRGB && (BUFFER_COLOR_SPACE==1);
 	}
 }

--- a/Shaders/DPX.fx
+++ b/Shaders/DPX.fx
@@ -30,6 +30,16 @@ uniform float Strength < __UNIFORM_SLIDER_FLOAT1
 
 #include "ReShade.fxh"
 
+#ifndef SWEETFX_DPX_SRGB
+#define SWEETFX_DPX_SRGB 1
+#endif
+
+sampler2D BackBuffer
+{
+	Texture = ReShade::BackBufferTex;
+	SRGBTexture = SWEETFX_DPX_SRGB && (BUFFER_COLOR_SPACE==1);
+};
+
 static const float3x3 RGB = float3x3(
 	 2.6714711726599600, -1.2672360578624100, -0.4109956021722270,
 	-1.0251070293466400,  1.9840911624108900,  0.0439502493584124,
@@ -43,7 +53,7 @@ static const float3x3 XYZ = float3x3(
 
 float3 DPXPass(float4 vois : SV_Position, float2 texcoord : TexCoord) : SV_Target
 {
-	float3 input = tex2D(ReShade::BackBuffer, texcoord).rgb;
+	float3 input = tex2D(BackBuffer, texcoord).rgb;
 
 	float3 B = input;
 	B = B * (1.0 - Contrast) + (0.5 * Contrast);
@@ -69,5 +79,6 @@ technique DPX
 	{
 		VertexShader = PostProcessVS;
 		PixelShader = DPXPass;
+		SRGBWriteEnable = SWEETFX_DPX_SRGB && (BUFFER_COLOR_SPACE==1);
 	}
 }

--- a/Shaders/FakeHDR.fx
+++ b/Shaders/FakeHDR.fx
@@ -23,29 +23,39 @@ uniform float radius2 < __UNIFORM_SLIDER_FLOAT1
 
 #include "ReShade.fxh"
 
+#ifndef SWEETFX_HDR_SRGB
+#define SWEETFX_HDR_SRGB 1
+#endif
+
+sampler2D BackBuffer
+{
+	Texture = ReShade::BackBufferTex;
+	SRGBTexture = SWEETFX_HDR_SRGB && (BUFFER_COLOR_SPACE==1);
+};
+
 float3 HDRPass(float4 vpos : SV_Position, float2 texcoord : TexCoord) : SV_Target
 {
-	float3 color = tex2D(ReShade::BackBuffer, texcoord).rgb;
+	float3 color = tex2D(BackBuffer, texcoord).rgb;
 
-	float3 bloom_sum1 = tex2D(ReShade::BackBuffer, texcoord + float2(1.5, -1.5) * radius1 * BUFFER_PIXEL_SIZE).rgb;
-	bloom_sum1 += tex2D(ReShade::BackBuffer, texcoord + float2(-1.5, -1.5) * radius1 * BUFFER_PIXEL_SIZE).rgb;
-	bloom_sum1 += tex2D(ReShade::BackBuffer, texcoord + float2( 1.5,  1.5) * radius1 * BUFFER_PIXEL_SIZE).rgb;
-	bloom_sum1 += tex2D(ReShade::BackBuffer, texcoord + float2(-1.5,  1.5) * radius1 * BUFFER_PIXEL_SIZE).rgb;
-	bloom_sum1 += tex2D(ReShade::BackBuffer, texcoord + float2( 0.0, -2.5) * radius1 * BUFFER_PIXEL_SIZE).rgb;
-	bloom_sum1 += tex2D(ReShade::BackBuffer, texcoord + float2( 0.0,  2.5) * radius1 * BUFFER_PIXEL_SIZE).rgb;
-	bloom_sum1 += tex2D(ReShade::BackBuffer, texcoord + float2(-2.5,  0.0) * radius1 * BUFFER_PIXEL_SIZE).rgb;
-	bloom_sum1 += tex2D(ReShade::BackBuffer, texcoord + float2( 2.5,  0.0) * radius1 * BUFFER_PIXEL_SIZE).rgb;
+	float3 bloom_sum1 = tex2D(BackBuffer, texcoord + float2(1.5, -1.5) * radius1 * BUFFER_PIXEL_SIZE).rgb;
+	bloom_sum1 += tex2D(BackBuffer, texcoord + float2(-1.5, -1.5) * radius1 * BUFFER_PIXEL_SIZE).rgb;
+	bloom_sum1 += tex2D(BackBuffer, texcoord + float2( 1.5,  1.5) * radius1 * BUFFER_PIXEL_SIZE).rgb;
+	bloom_sum1 += tex2D(BackBuffer, texcoord + float2(-1.5,  1.5) * radius1 * BUFFER_PIXEL_SIZE).rgb;
+	bloom_sum1 += tex2D(BackBuffer, texcoord + float2( 0.0, -2.5) * radius1 * BUFFER_PIXEL_SIZE).rgb;
+	bloom_sum1 += tex2D(BackBuffer, texcoord + float2( 0.0,  2.5) * radius1 * BUFFER_PIXEL_SIZE).rgb;
+	bloom_sum1 += tex2D(BackBuffer, texcoord + float2(-2.5,  0.0) * radius1 * BUFFER_PIXEL_SIZE).rgb;
+	bloom_sum1 += tex2D(BackBuffer, texcoord + float2( 2.5,  0.0) * radius1 * BUFFER_PIXEL_SIZE).rgb;
 
 	bloom_sum1 *= 0.005;
 
-	float3 bloom_sum2 = tex2D(ReShade::BackBuffer, texcoord + float2(1.5, -1.5) * radius2 * BUFFER_PIXEL_SIZE).rgb;
-	bloom_sum2 += tex2D(ReShade::BackBuffer, texcoord + float2(-1.5, -1.5) * radius2 * BUFFER_PIXEL_SIZE).rgb;
-	bloom_sum2 += tex2D(ReShade::BackBuffer, texcoord + float2( 1.5,  1.5) * radius2 * BUFFER_PIXEL_SIZE).rgb;
-	bloom_sum2 += tex2D(ReShade::BackBuffer, texcoord + float2(-1.5,  1.5) * radius2 * BUFFER_PIXEL_SIZE).rgb;
-	bloom_sum2 += tex2D(ReShade::BackBuffer, texcoord + float2( 0.0, -2.5) * radius2 * BUFFER_PIXEL_SIZE).rgb;	
-	bloom_sum2 += tex2D(ReShade::BackBuffer, texcoord + float2( 0.0,  2.5) * radius2 * BUFFER_PIXEL_SIZE).rgb;
-	bloom_sum2 += tex2D(ReShade::BackBuffer, texcoord + float2(-2.5,  0.0) * radius2 * BUFFER_PIXEL_SIZE).rgb;
-	bloom_sum2 += tex2D(ReShade::BackBuffer, texcoord + float2( 2.5,  0.0) * radius2 * BUFFER_PIXEL_SIZE).rgb;
+	float3 bloom_sum2 = tex2D(BackBuffer, texcoord + float2(1.5, -1.5) * radius2 * BUFFER_PIXEL_SIZE).rgb;
+	bloom_sum2 += tex2D(BackBuffer, texcoord + float2(-1.5, -1.5) * radius2 * BUFFER_PIXEL_SIZE).rgb;
+	bloom_sum2 += tex2D(BackBuffer, texcoord + float2( 1.5,  1.5) * radius2 * BUFFER_PIXEL_SIZE).rgb;
+	bloom_sum2 += tex2D(BackBuffer, texcoord + float2(-1.5,  1.5) * radius2 * BUFFER_PIXEL_SIZE).rgb;
+	bloom_sum2 += tex2D(BackBuffer, texcoord + float2( 0.0, -2.5) * radius2 * BUFFER_PIXEL_SIZE).rgb;	
+	bloom_sum2 += tex2D(BackBuffer, texcoord + float2( 0.0,  2.5) * radius2 * BUFFER_PIXEL_SIZE).rgb;
+	bloom_sum2 += tex2D(BackBuffer, texcoord + float2(-2.5,  0.0) * radius2 * BUFFER_PIXEL_SIZE).rgb;
+	bloom_sum2 += tex2D(BackBuffer, texcoord + float2( 2.5,  0.0) * radius2 * BUFFER_PIXEL_SIZE).rgb;
 
 	bloom_sum2 *= 0.010;
 
@@ -63,5 +73,6 @@ technique HDR
 	{
 		VertexShader = PostProcessVS;
 		PixelShader = HDRPass;
+		SRGBWriteEnable = SWEETFX_HDR_SRGB && (BUFFER_COLOR_SPACE==1);
 	}
 }

--- a/Shaders/Levels.fx
+++ b/Shaders/Levels.fx
@@ -44,6 +44,16 @@ uniform bool HighlightClipping <
 
 #include "ReShade.fxh"
 
+#ifndef SWEETFX_LEVELS_SRGB
+#define SWEETFX_LEVELS_SRGB 1
+#endif
+
+sampler2D BackBuffer
+{
+	Texture = ReShade::BackBufferTex;
+	SRGBTexture = SWEETFX_LEVELS_SRGB && (BUFFER_COLOR_SPACE==1);
+};
+
 float3 LevelsPass(float4 vpos : SV_Position, float2 texcoord : TexCoord) : SV_Target
 {
 	float black_point_float = BlackPoint / 255.0;
@@ -81,5 +91,6 @@ technique Levels
 	{
 		VertexShader = PostProcessVS;
 		PixelShader = LevelsPass;
+		SRGBWriteEnable = SWEETFX_LEVELS_SRGB && (BUFFER_COLOR_SPACE==1);
 	}
 }

--- a/Shaders/LumaSharpen.fx
+++ b/Shaders/LumaSharpen.fx
@@ -48,6 +48,16 @@ uniform bool show_sharpen <
 
 #include "ReShade.fxh"
 
+#ifndef SWEETFX_SHARP_SRGB
+#define SWEETFX_SHARP_SRGB 1
+#endif
+
+sampler2D BackBuffer
+{
+	Texture = ReShade::BackBufferTex;
+	SRGBTexture = SWEETFX_SHARP_SRGB && (BUFFER_COLOR_SPACE==1);
+};
+
    /*-----------------------------------------------------------.
   /                      Developer settings                     /
   '-----------------------------------------------------------*/
@@ -62,7 +72,7 @@ uniform bool show_sharpen <
 float3 LumaSharpenPass(float4 position : SV_Position, float2 tex : TEXCOORD) : SV_Target
 {
 	// -- Get the original pixel --
-	float3 ori = tex2D(ReShade::BackBuffer, tex).rgb; // ori = original pixel
+	float3 ori = tex2D(BackBuffer, tex).rgb; // ori = original pixel
 
 	// -- Combining the strength and luma multipliers --
 	float3 sharp_strength_luma = (CoefLuma * sharp_strength); //I'll be combining even more multipliers with it later on
@@ -84,11 +94,11 @@ float3 LumaSharpenPass(float4 position : SV_Position, float2 tex : TEXCOORD) : S
 		//   [ 2/9, 8/9, 2/9]  =  [ 2 , 8 , 2 ]
 		//   [    , 2/9, 1/9]     [   , 2 , 1 ]
 
-		blur_ori  = tex2D(ReShade::BackBuffer, tex + (BUFFER_PIXEL_SIZE / 3.0) * offset_bias).rgb;  // North West
-		blur_ori += tex2D(ReShade::BackBuffer, tex + (-BUFFER_PIXEL_SIZE / 3.0) * offset_bias).rgb; // South East
+		blur_ori  = tex2D(BackBuffer, tex + (BUFFER_PIXEL_SIZE / 3.0) * offset_bias).rgb;  // North West
+		blur_ori += tex2D(BackBuffer, tex + (-BUFFER_PIXEL_SIZE / 3.0) * offset_bias).rgb; // South East
 
-		//blur_ori += tex2D(ReShade::BackBuffer, tex + (BUFFER_PIXEL_SIZE / 3.0) * offset_bias); // North East
-		//blur_ori += tex2D(ReShade::BackBuffer, tex + (-BUFFER_PIXEL_SIZE / 3.0) * offset_bias); // South West
+		//blur_ori += tex2D(BackBuffer, tex + (BUFFER_PIXEL_SIZE / 3.0) * offset_bias); // North East
+		//blur_ori += tex2D(BackBuffer, tex + (-BUFFER_PIXEL_SIZE / 3.0) * offset_bias); // South West
 
 		blur_ori /= 2;  //Divide by the number of texture fetches
 
@@ -103,10 +113,10 @@ float3 LumaSharpenPass(float4 position : SV_Position, float2 tex : TEXCOORD) : S
 		//   [ .50,   1, .50]  =  [ 2 , 4 , 2 ]
 		//   [ .25, .50, .25]     [ 1 , 2 , 1 ]
 
-		blur_ori  = tex2D(ReShade::BackBuffer, tex + float2(BUFFER_PIXEL_SIZE.x, -BUFFER_PIXEL_SIZE.y) * 0.5 * offset_bias).rgb; // South East
-		blur_ori += tex2D(ReShade::BackBuffer, tex - BUFFER_PIXEL_SIZE * 0.5 * offset_bias).rgb;  // South West
-		blur_ori += tex2D(ReShade::BackBuffer, tex + BUFFER_PIXEL_SIZE * 0.5 * offset_bias).rgb; // North East
-		blur_ori += tex2D(ReShade::BackBuffer, tex - float2(BUFFER_PIXEL_SIZE.x, -BUFFER_PIXEL_SIZE.y) * 0.5 * offset_bias).rgb; // North West
+		blur_ori  = tex2D(BackBuffer, tex + float2(BUFFER_PIXEL_SIZE.x, -BUFFER_PIXEL_SIZE.y) * 0.5 * offset_bias).rgb; // South East
+		blur_ori += tex2D(BackBuffer, tex - BUFFER_PIXEL_SIZE * 0.5 * offset_bias).rgb;  // South West
+		blur_ori += tex2D(BackBuffer, tex + BUFFER_PIXEL_SIZE * 0.5 * offset_bias).rgb; // North East
+		blur_ori += tex2D(BackBuffer, tex - float2(BUFFER_PIXEL_SIZE.x, -BUFFER_PIXEL_SIZE.y) * 0.5 * offset_bias).rgb; // North West
 
 		blur_ori *= 0.25;  // ( /= 4) Divide by the number of texture fetches
 	}
@@ -121,10 +131,10 @@ float3 LumaSharpenPass(float4 position : SV_Position, float2 tex : TEXCOORD) : S
 		//   [ 4 ,16 ,24 ,16 ,   ]
 		//   [   ,   , 6 , 4 ,   ]
 
-		blur_ori  = tex2D(ReShade::BackBuffer, tex + BUFFER_PIXEL_SIZE * float2(0.4, -1.2) * offset_bias).rgb;  // South South East
-		blur_ori += tex2D(ReShade::BackBuffer, tex - BUFFER_PIXEL_SIZE * float2(1.2, 0.4) * offset_bias).rgb; // West South West
-		blur_ori += tex2D(ReShade::BackBuffer, tex + BUFFER_PIXEL_SIZE * float2(1.2, 0.4) * offset_bias).rgb; // East North East
-		blur_ori += tex2D(ReShade::BackBuffer, tex - BUFFER_PIXEL_SIZE * float2(0.4, -1.2) * offset_bias).rgb; // North North West
+		blur_ori  = tex2D(BackBuffer, tex + BUFFER_PIXEL_SIZE * float2(0.4, -1.2) * offset_bias).rgb;  // South South East
+		blur_ori += tex2D(BackBuffer, tex - BUFFER_PIXEL_SIZE * float2(1.2, 0.4) * offset_bias).rgb; // West South West
+		blur_ori += tex2D(BackBuffer, tex + BUFFER_PIXEL_SIZE * float2(1.2, 0.4) * offset_bias).rgb; // East North East
+		blur_ori += tex2D(BackBuffer, tex - BUFFER_PIXEL_SIZE * float2(0.4, -1.2) * offset_bias).rgb; // North North West
 
 		blur_ori *= 0.25;  // ( /= 4) Divide by the number of texture fetches
 
@@ -139,10 +149,10 @@ float3 LumaSharpenPass(float4 position : SV_Position, float2 tex : TEXCOORD) : S
 		//   [ .50,    , .50]  =  [ 1 ,   , 1 ]
 		//   [ .50, .50, .50]     [ 1 , 1 , 1 ]
 
-		blur_ori  = tex2D(ReShade::BackBuffer, tex + float2(0.5 * BUFFER_PIXEL_SIZE.x, -BUFFER_PIXEL_SIZE.y * offset_bias)).rgb;  // South South East
-		blur_ori += tex2D(ReShade::BackBuffer, tex + float2(offset_bias * -BUFFER_PIXEL_SIZE.x, 0.5 * -BUFFER_PIXEL_SIZE.y)).rgb; // West South West
-		blur_ori += tex2D(ReShade::BackBuffer, tex + float2(offset_bias * BUFFER_PIXEL_SIZE.x, 0.5 * BUFFER_PIXEL_SIZE.y)).rgb; // East North East
-		blur_ori += tex2D(ReShade::BackBuffer, tex + float2(0.5 * -BUFFER_PIXEL_SIZE.x, BUFFER_PIXEL_SIZE.y * offset_bias)).rgb; // North North West
+		blur_ori  = tex2D(BackBuffer, tex + float2(0.5 * BUFFER_PIXEL_SIZE.x, -BUFFER_PIXEL_SIZE.y * offset_bias)).rgb;  // South South East
+		blur_ori += tex2D(BackBuffer, tex + float2(offset_bias * -BUFFER_PIXEL_SIZE.x, 0.5 * -BUFFER_PIXEL_SIZE.y)).rgb; // West South West
+		blur_ori += tex2D(BackBuffer, tex + float2(offset_bias * BUFFER_PIXEL_SIZE.x, 0.5 * BUFFER_PIXEL_SIZE.y)).rgb; // East North East
+		blur_ori += tex2D(BackBuffer, tex + float2(0.5 * -BUFFER_PIXEL_SIZE.x, BUFFER_PIXEL_SIZE.y * offset_bias)).rgb; // North North West
 
 		//blur_ori += (2 * ori); // Probably not needed. Only serves to lessen the effect.
 
@@ -196,5 +206,6 @@ technique LumaSharpen
 	{
 		VertexShader = PostProcessVS;
 		PixelShader = LumaSharpenPass;
+		SRGBWriteEnable = SWEETFX_SHARP_SRGB && (BUFFER_COLOR_SPACE==1);
 	}
 }

--- a/Shaders/Monochrome.fx
+++ b/Shaders/Monochrome.fx
@@ -81,9 +81,19 @@ uniform float Monochrome_color_saturation < __UNIFORM_SLIDER_FLOAT1
 	ui_min = 0.0; ui_max = 1.0;
 > = 0.0;
 
+#ifndef SWEETFX_MONOCHROME_SRGB
+#define SWEETFX_MONOCHROME_SRGB 1
+#endif
+
+sampler2D BackBuffer
+{
+	Texture = ReShade::BackBufferTex;
+	SRGBTexture = SWEETFX_MONOCHROME_SRGB && (BUFFER_COLOR_SPACE==1);
+};
+
 float3 MonochromePass(float4 vpos : SV_Position, float2 texcoord : TexCoord) : SV_Target
 {
-	float3 color = tex2D(ReShade::BackBuffer, texcoord).rgb;
+	float3 color = tex2D(BackBuffer, texcoord).rgb;
 
 	float3 Coefficients = float3(0.21, 0.72, 0.07);
 
@@ -127,5 +137,6 @@ technique Monochrome
 	{
 		VertexShader = PostProcessVS;
 		PixelShader = MonochromePass;
+		SRGBWriteEnable = SWEETFX_MONOCHROME_SRGB && (BUFFER_COLOR_SPACE==1);
 	}
 }

--- a/Shaders/Technicolor.fx
+++ b/Shaders/Technicolor.fx
@@ -19,6 +19,16 @@ uniform float Strength < __UNIFORM_SLIDER_FLOAT1
 
 #include "ReShade.fxh"
 
+#ifndef SWEETFX_TC_SRGB
+#define SWEETFX_TC_SRGB 1
+#endif
+
+sampler2D BackBuffer
+{
+	Texture = ReShade::BackBufferTex;
+	SRGBTexture = SWEETFX_TC_SRGB && (BUFFER_COLOR_SPACE==1);
+};
+
 float3 TechnicolorPass(float4 vpos : SV_Position, float2 texcoord : TexCoord) : SV_Target
 {
 	const float3 cyanfilter = float3(0.0, 1.30, 1.0);
@@ -28,7 +38,7 @@ float3 TechnicolorPass(float4 vpos : SV_Position, float2 texcoord : TexCoord) : 
 	const float2 greenfilter = float2(0.30, 1.0);       // RG_
 	const float2 magentafilter2 = magentafilter.rb;     // R_B
 
-	float3 tcol = tex2D(ReShade::BackBuffer, texcoord).rgb;
+	float3 tcol = tex2D(BackBuffer, texcoord).rgb;
 	
 	float2 negative_mul_r = tcol.rg * (1.0 / (RGBNegativeAmount.r * Power));
 	float2 negative_mul_g = tcol.rg * (1.0 / (RGBNegativeAmount.g * Power));
@@ -46,5 +56,6 @@ technique Technicolor
 	{
 		VertexShader = PostProcessVS;
 		PixelShader = TechnicolorPass;
+		SRGBWriteEnable = SWEETFX_TC_SRGB && (BUFFER_COLOR_SPACE==1);
 	}
 }

--- a/Shaders/Technicolor2.fx
+++ b/Shaders/Technicolor2.fx
@@ -26,9 +26,19 @@ uniform float Strength < __UNIFORM_SLIDER_FLOAT1
 
 #include "ReShade.fxh"
 
+#ifndef SWEETFX_TC2_SRGB
+#define SWEETFX_TC2_SRGB 1
+#endif
+
+sampler2D BackBuffer
+{
+	Texture = ReShade::BackBufferTex;
+	SRGBTexture = SWEETFX_TC2_SRGB && (BUFFER_COLOR_SPACE==1);
+};
+
 float3 TechnicolorPass(float4 vpos : SV_Position, float2 texcoord : TexCoord) : SV_Target
 {
-	float3 color = saturate(tex2D(ReShade::BackBuffer, texcoord).rgb);
+	float3 color = saturate(tex2D(BackBuffer, texcoord).rgb);
 	
 	float3 temp = 1.0 - color;
 	float3 target = temp.grg;
@@ -58,5 +68,6 @@ technique Technicolor2
 	{
 		VertexShader = PostProcessVS;
 		PixelShader = TechnicolorPass;
+		SRGBWriteEnable = SWEETFX_TC2_SRGB && (BUFFER_COLOR_SPACE==1);
 	}
 }

--- a/Shaders/Tonemap.fx
+++ b/Shaders/Tonemap.fx
@@ -35,9 +35,19 @@ uniform float3 FogColor < __UNIFORM_COLOR_FLOAT3
 
 #include "ReShade.fxh"
 
+#ifndef SWEETFX_TMO_SRGB
+#define SWEETFX_TMO_SRGB 1
+#endif
+
+sampler2D BackBuffer
+{
+	Texture = ReShade::BackBufferTex;
+	SRGBTexture = SWEETFX_TMO_SRGB && (BUFFER_COLOR_SPACE==1);
+};
+
 float3 TonemapPass(float4 position : SV_Position, float2 texcoord : TexCoord) : SV_Target
 {
-	float3 color = tex2D(ReShade::BackBuffer, texcoord).rgb;
+	float3 color = tex2D(BackBuffer, texcoord).rgb;
 	color = saturate(color - Defog * FogColor * 2.55); // Defog
 	color *= pow(2.0f, Exposure); // Exposure
 	color = pow(color, Gamma); // Gamma
@@ -68,5 +78,6 @@ technique Tonemap
 	{
 		VertexShader = PostProcessVS;
 		PixelShader = TonemapPass;
+		SRGBWriteEnable = SWEETFX_TMO_SRGB && (BUFFER_COLOR_SPACE==1);
 	}
 }

--- a/Shaders/Vibrance.fx
+++ b/Shaders/Vibrance.fx
@@ -39,9 +39,19 @@ uniform int Vibrance_Luma <
 
 #include "ReShade.fxh"
 
+#ifndef SWEETFX_VIBRANCE_SRGB
+#define SWEETFX_VIBRANCE_SRGB 1
+#endif
+
+sampler2D BackBuffer
+{
+	Texture = ReShade::BackBufferTex;
+	SRGBTexture = SWEETFX_VIBRANCE_SRGB && (BUFFER_COLOR_SPACE==1);
+};
+
 float3 VibrancePass(float4 position : SV_Position, float2 texcoord : TexCoord) : SV_Target
 {
-	float3 color = tex2D(ReShade::BackBuffer, texcoord).rgb;
+	float3 color = tex2D(BackBuffer, texcoord).rgb;
   
 	float3 coefLuma = float3(0.212656, 0.715158, 0.072186);
 	
@@ -71,5 +81,6 @@ technique Vibrance
 	{
 		VertexShader = PostProcessVS;
 		PixelShader = VibrancePass;
+		SRGBWriteEnable = SWEETFX_VIBRANCE_SRGB && (BUFFER_COLOR_SPACE==1);
 	}
 }

--- a/Shaders/Vignette.fx
+++ b/Shaders/Vignette.fx
@@ -35,9 +35,19 @@ uniform float2 Center < __UNIFORM_SLIDER_FLOAT2
 
 #include "ReShade.fxh"
 
+#ifndef SWEETFX_VIGNETTE_SRGB
+#define SWEETFX_VIGNETTE_SRGB 1
+#endif
+
+sampler2D BackBuffer
+{
+	Texture = ReShade::BackBufferTex;
+	SRGBTexture = SWEETFX_VIGNETTE_SRGB && (BUFFER_COLOR_SPACE==1);
+};
+
 float4 VignettePass(float4 vpos : SV_Position, float2 tex : TexCoord) : SV_Target
 {
-	float4 color = tex2D(ReShade::BackBuffer, tex);
+	float4 color = tex2D(BackBuffer, tex);
 
 	if (Type == 0)
 	{
@@ -111,5 +121,6 @@ technique Vignette
 	{
 		VertexShader = PostProcessVS;
 		PixelShader = VignettePass;
+		SRGBWriteEnable = SWEETFX_VIGNETTE_SRGB && (BUFFER_COLOR_SPACE==1);
 	}
 }


### PR DESCRIPTION
This PR will add SRGB linearization (with user controls) to all SweetFX shaders that are meant to be used with linear SRGB but were not coded that way.